### PR TITLE
Update runtime to 46>50 and more

### DIFF
--- a/org.sugarlabs.SwiftFeet.json
+++ b/org.sugarlabs.SwiftFeet.json
@@ -1,9 +1,9 @@
 {
     "app-id": "org.sugarlabs.SwiftFeet",
     "base": "org.sugarlabs.BaseApp",
-    "base-version": "24.04",
+    "base-version": "26.04",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "separate-locales": false,
     "command": "sugarapp",
@@ -14,6 +14,9 @@
         "--device=dri",
         "--env=SUGAR_BUNDLE_ID=org.sugarlabs.SwiftFeet",
         "--env=SUGAR_BUNDLE_PATH=/app/share/sugar/activities/SwiftFeet.activity"
+    ],
+    "cleanup-commands": [
+        "rm -rf /app/share/gir-1.0"
     ],
     "modules": [
         {

--- a/swiftfeet-info.patch
+++ b/swiftfeet-info.patch
@@ -21,4 +21,4 @@ index f8a3b41..86e1d6a 100644
 +update_contact = tch@sugarlabs.org
 +developer_name = Sugar Labs Community
 +developer_id = org.sugarlabs
-+screenshots = http://activities.sugarlabs.org/en-US/sugar/images/p/995/1363971396
++screenshots = https://imgproxy.flathub.org/insecure/dpr:2/f:avif/rs:fill-down/aHR0cHM6Ly9kbC5mbGF0aHViLm9yZy9tZWRpYS9vcmcvc3VnYXJsYWJzL1N3aWZ0RmVldC9mOTA0NzJhZjA5NzJhNDQ3MjY0NmU0NGM0MGExMzJlZS9zY3JlZW5zaG90cy9pbWFnZS0xX29yaWcucG5n


### PR DESCRIPTION
- Update the runtime version to 50
- Improve cleanup commands to reduce the Flatpak size
- Fix appdata paper cuts
- Move the patches to the patches folder